### PR TITLE
Standardize hero layout across pages

### DIFF
--- a/CDA-WEBSITE/cda-frontend/src/app/about/page.js
+++ b/CDA-WEBSITE/cda-frontend/src/app/about/page.js
@@ -1,5 +1,6 @@
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import HeroSection from '../../components/GlobalBlocks/HeroSection';
 import PhotoFrame from '../../components/GlobalBlocks/PhotoFrame';
 import WhyCdaBlock from '../../components/GlobalBlocks/WhyCdaBlock';
 import ServicesAccordion from '../../components/GlobalBlocks/ServicesAccordion';
@@ -68,43 +69,39 @@ export default async function AboutPage() {
     <>
       <Header />
       
-      {/* 1) Hero individual (uses same classes as homepage hero) */}
+      {/* 1) Hero individual */}
       {aboutContent?.contentPageHeader && (
-        <section className="home-hero-section bg-white">
-          <div className="home-header-grid mx-auto w-full max-w-[1620px] px-4 md:px-6 lg:px-8">
-            <div className="home-header-text text-center md:text-left">
-              <h1
-                className="cda-page-title title-large-pink"
-                dangerouslySetInnerHTML={{ __html: sanitizeTitleHtml(aboutContent.contentPageHeader.title || 'About Us') }}
+        <HeroSection
+          sectionClassName="bg-white"
+          titleHtml={sanitizeTitleHtml(aboutContent.contentPageHeader.title || 'About Us')}
+          titleClassName="cda-page-title title-large-pink"
+          descriptionHtml={aboutContent.contentPageHeader.text || ''}
+          ctas={[
+            aboutContent.contentPageHeader.cta
+              ? {
+                  href: aboutContent.contentPageHeader.cta.url || '#',
+                  label: aboutContent.contentPageHeader.cta.title || 'Get Started',
+                  target: aboutContent.contentPageHeader.cta.target || '_self',
+                  className: 'button-without-box',
+                }
+              : null,
+          ]}
+          image={
+            aboutContent.contentPageHeader.image?.node?.sourceUrl ? (
+              <img
+                src={aboutContent.contentPageHeader.image.node.sourceUrl}
+                alt={aboutContent.contentPageHeader.image.node.altText || 'About illustration'}
+                width={700}
+                height={520}
+                className="cda-hero__image-media"
               />
-              {aboutContent.contentPageHeader.text && (
-                <div className="home-hero-subtitle" dangerouslySetInnerHTML={{ __html: aboutContent.contentPageHeader.text }} />
-              )}
-              {aboutContent.contentPageHeader.cta && (
-                <div className="home-header-cta home-hero-cta">
-                  <a href={aboutContent.contentPageHeader.cta.url || '#'} className="button-without-box" target={aboutContent.contentPageHeader.cta.target || '_self'}>
-                    {aboutContent.contentPageHeader.cta.title || 'Get Started'}
-                  </a>
-                </div>
-              )}
-            </div>
-            <div className="home-header-illustration-wrap">
-              {aboutContent.contentPageHeader.image?.node?.sourceUrl ? (
-                <img
-                  src={aboutContent.contentPageHeader.image.node.sourceUrl}
-                  alt={aboutContent.contentPageHeader.image.node.altText || 'About illustration'}
-                  width={700}
-                  height={520}
-                  className="home-header-illustration"
-                />
-              ) : (
-                <div className="home-hero-illustration-placeholder">
-                  <p>Upload illustration in WordPress Admin → Pages → Edit About → Header Section</p>
-                </div>
-              )}
-            </div>
-          </div>
-        </section>
+            ) : (
+              <div className="cda-hero__image-placeholder">
+                <p>Upload illustration in WordPress Admin → Pages → Edit About → Header Section</p>
+              </div>
+            )
+          }
+        />
       )}
 
       {/* Order below: 2 Image Frame, 3 WhyCda, 4 Services Accordion, 5 Culture Gallery, 6 Approach, 7 Stats, 8 Full Video, 9 Custom (placeholder), 10 Showreel */}

--- a/CDA-WEBSITE/cda-frontend/src/app/page.js
+++ b/CDA-WEBSITE/cda-frontend/src/app/page.js
@@ -1,5 +1,6 @@
 import Header from '../components/Header'
 import Footer from '../components/Footer'
+import HeroSection from '../components/GlobalBlocks/HeroSection'
 import { sanitizeTitleHtml } from '../lib/sanitizeTitleHtml'
 import PhotoFrame from '../components/GlobalBlocks/PhotoFrame'
 import ServicesAccordion from '../components/GlobalBlocks/ServicesAccordion'
@@ -187,46 +188,45 @@ export default async function Home() {
 
       {/* 1) Hero individual */}
       {hero && (
-        <section className="home-hero-section bg-white">
-          <div className="home-header-grid mx-auto w-full max-w-[1620px] px-4 md:px-6 lg:px-8">
-            <div className="home-header-text text-center md:text-left">
-              <h1
-                className="cda-page-title title-large-light-blue"
-                dangerouslySetInnerHTML={{ __html: sanitizeTitleHtml(hero.title || 'Welcome to CDA') }}
+        <HeroSection
+          sectionClassName="bg-white"
+          titleHtml={sanitizeTitleHtml(hero.title || 'Welcome to CDA')}
+          titleClassName="cda-page-title title-large-light-blue"
+          description={hero.text}
+          ctas={[
+            hero.button1
+              ? {
+                  href: hero.button1.url || '#',
+                  label: hero.button1.title || 'Start A Project',
+                  target: hero.button1.target || '_self',
+                  className: 'button-l',
+                }
+              : null,
+            hero.button2
+              ? {
+                  href: hero.button2.url || '#',
+                  label: hero.button2.title || 'View Our Services',
+                  target: hero.button2.target || '_self',
+                  className: 'button-without-box',
+                }
+              : null,
+          ]}
+          image={
+            hero.illustration?.node?.sourceUrl ? (
+              <img
+                src={hero.illustration.node.sourceUrl}
+                alt={hero.illustration.node.altText || 'Header illustration'}
+                width={700}
+                height={520}
+                className="cda-hero__image-media"
               />
-              {hero.text && (
-                <p className="home-hero-subtitle">{hero.text}</p>
-              )}
-              <div className="home-header-cta home-hero-cta">
-                {hero.button1 && (
-                  <a href={hero.button1.url || '#'} className="button-l" target={hero.button1.target || '_self'}>
-                    {hero.button1.title || 'Start A Project'}
-                  </a>
-                )}
-                {hero.button2 && (
-                  <a href={hero.button2.url || '#'} className="button-without-box" target={hero.button2.target || '_self'}>
-                    {hero.button2.title || 'View Our Services'}
-                  </a>
-                )}
+            ) : (
+              <div className="cda-hero__image-placeholder">
+                <p>Upload illustration in WordPress Admin → Pages → Edit Homepage → Header Section</p>
               </div>
-            </div>
-            <div className="home-header-illustration-wrap">
-              {hero.illustration?.node?.sourceUrl ? (
-                <img
-                  src={hero.illustration.node.sourceUrl}
-                  alt={hero.illustration.node.altText || 'Header illustration'}
-                  width={700}
-                  height={520}
-                  className="home-header-illustration"
-                />
-              ) : (
-                <div className="home-hero-illustration-placeholder">
-                  <p>Upload illustration in WordPress Admin → Pages → Edit Homepage → Header Section</p>
-                </div>
-              )}
-            </div>
-          </div>
-        </section>
+            )
+          }
+        />
       )}
 
       {/* 2) [Global] Image Frame Block */}

--- a/CDA-WEBSITE/cda-frontend/src/app/services/[slug]/page.js
+++ b/CDA-WEBSITE/cda-frontend/src/app/services/[slug]/page.js
@@ -1,5 +1,6 @@
 import Header from '../../../components/Header';
 import Footer from '../../../components/Footer';
+import HeroSection from '../../../components/GlobalBlocks/HeroSection';
 import { notFound } from 'next/navigation';
 import { sanitizeTitleHtml } from '../../../lib/sanitizeTitleHtml';
 import { executeGraphQLQuery, GET_SERVICE_BY_SLUG } from '../../../lib/graphql-queries';
@@ -47,6 +48,31 @@ export default async function ServicePage({ params }) {
   const valueDescription = serviceFields.valueDescription || {};
   const featuredCaseStudies = serviceFields.caseStudies?.nodes || [];
   const serviceColor = getServiceColor(service.slug);
+  const heroImageNode = heroSection.heroImage?.node?.sourceUrl
+    ? (
+        <Image
+          src={heroSection.heroImage.node.sourceUrl}
+          alt={heroSection.heroImage.node.altText || service.title}
+          width={600}
+          height={400}
+          className="cda-hero__image-media"
+          style={{ maxHeight: '600px', objectFit: 'contain' }}
+          priority
+        />
+      )
+    : service.featuredImage?.node?.sourceUrl
+      ? (
+          <Image
+            src={service.featuredImage.node.sourceUrl}
+            alt={service.featuredImage.node.altText || service.title}
+            width={600}
+            height={400}
+            className="cda-hero__image-media"
+            style={{ maxHeight: '600px', objectFit: 'contain' }}
+            priority
+          />
+        )
+      : null;
 
   // Global content blocks
   const globalContentBlocks = globalData?.globalContentBlocks || {};
@@ -65,33 +91,26 @@ export default async function ServicePage({ params }) {
       <Header />
       <main className="service-detail-page">
         {/* Hero Section */}
-        <section className="service-hero">
-          <div className="container mx-auto px-4 py-16 lg:py-24">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-              <div className="service-hero-content">
-                <h1 
-                  className="service-hero-title text-4xl lg:text-5xl font-bold mb-6"
-                  style={{ textDecoration: 'underline', textDecorationColor: serviceColor, textDecorationThickness: '11px' }}
-                >
-                  {sanitizeTitleHtml(service.title)}
-                </h1>
-                {heroSection.description && (
-                  <div className="service-hero-description text-lg text-gray-600 mb-8" dangerouslySetInnerHTML={{ __html: heroSection.description }} />
-                )}
-                {heroSection.cta?.title && (
-                  <a href="#contact-form" className="button-l">{heroSection.cta.title}</a>
-                )}
-              </div>
-              <div className="service-hero-image">
-                {heroSection.heroImage?.node?.sourceUrl ? (
-                  <Image src={heroSection.heroImage.node.sourceUrl} alt={heroSection.heroImage.node.altText || service.title} width={600} height={400} className="w-full h-auto rounded-lg" style={{ maxHeight: '600px', objectFit: 'contain' }} priority />
-                ) : service.featuredImage?.node?.sourceUrl && (
-                  <Image src={service.featuredImage.node.sourceUrl} alt={service.featuredImage.node.altText || service.title} width={600} height={400} className="w-full h-auto rounded-lg" style={{ maxHeight: '600px', objectFit: 'contain' }} priority />
-                )}
-              </div>
-            </div>
-          </div>
-        </section>
+        <HeroSection
+          sectionClassName="bg-white"
+          eyebrow={heroSection.subtitle || ''}
+          eyebrowClassName="service-hero-subtitle"
+          titleHtml={sanitizeTitleHtml(service.title)}
+          titleClassName="service-hero-title text-4xl lg:text-5xl font-bold"
+          titleStyle={{ textDecoration: 'underline', textDecorationColor: serviceColor, textDecorationThickness: '11px' }}
+          descriptionHtml={heroSection.description || ''}
+          descriptionClassName="service-hero-description text-lg text-gray-600"
+          ctas={[
+            heroSection.cta?.title
+              ? {
+                  href: '#contact-form',
+                  label: heroSection.cta.title,
+                  className: 'button-l',
+                }
+              : null,
+          ]}
+          image={heroImageNode}
+        />
 
 
 

--- a/CDA-WEBSITE/cda-frontend/src/app/services/page.js
+++ b/CDA-WEBSITE/cda-frontend/src/app/services/page.js
@@ -2,6 +2,7 @@
 import { getServicesWithPagination, executeGraphQLQuery, getServiceOverviewContent, getServiceBySlug } from '@/lib/graphql-queries.js'
 import ServicesClient from './ServicesClient'
 import ApproachBlock from '@/components/GlobalBlocks/ApproachBlock'
+import HeroSection from '@/components/GlobalBlocks/HeroSection'
 import ValuesBlock from '@/components/GlobalBlocks/ValuesBlock'
 import ServicesProcess from '@/components/Sections/ServicesProcess'
 import ServicesStats from '@/components/Sections/ServicesStats'
@@ -159,41 +160,37 @@ export default async function ServicesPage() {
       }
     }
 
+    const heroSectionContent = overviewContent?.heroSection || {}
+    const heroImageNode = heroSectionContent.imageRight?.node?.sourceUrl
+      ? (
+          <Image
+            src={heroSectionContent.imageRight.node.sourceUrl}
+            alt={heroSectionContent.imageRight.node.altText || 'Our Services'}
+            width={600}
+            height={400}
+            className="cda-hero__image-media"
+            priority
+          />
+        )
+      : null
+
+    const heroDescription =
+      heroSectionContent.description ||
+      'Discover our comprehensive range of digital services designed to help your business grow and succeed in the digital landscape.'
+
     return (
       <>
         <Header />
-        <div className="min-h-screen bg-white">
+        <main className="min-h-screen bg-white">
+          <HeroSection
+            sectionClassName="bg-white"
+            title={heroSectionContent.title || 'Our Services'}
+            titleClassName="text-4xl font-bold text-gray-900"
+            description={heroDescription}
+            descriptionClassName="text-xl text-gray-600"
+            image={heroImageNode}
+          />
           <div className="max-w-7xl mx-auto px-4 py-16">
-          {/* Hero Section */}
-          <section className="relative bg-white p-8 mb-12 overflow-hidden">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center max-w-7xl mx-auto">
-              <div className="relative z-10">
-                <h1 className="text-4xl font-bold text-gray-900 mb-4">
-                  {overviewContent?.heroSection?.title || 'Our Services'}
-                </h1>
-                <p className="text-xl text-gray-600 mb-8">
-                  {overviewContent?.heroSection?.description || 'Discover our comprehensive range of digital services designed to help your business grow and succeed in the digital landscape.'}
-                </p>
-              </div>
-              
-              {/* Hero Image Right */}
-              {overviewContent?.heroSection?.imageRight?.node?.sourceUrl && (
-                <div className="relative">
-                  <Image
-                    src={overviewContent.heroSection.imageRight.node.sourceUrl}
-                    alt={overviewContent.heroSection.imageRight.node.altText || 'Our Services'}
-                    width={600}
-                    height={400}
-                    className="w-full h-auto rounded-lg shadow-lg"
-                    priority
-                  />
-                </div>
-              )}
-            </div>
-          </section>
-
-
-
           {/* Service Landing Two-Column Section */}
           {(overviewContent?.featuredServiceSection || overviewContent?.rightColumn) && (
             <section className="mb-12">
@@ -318,7 +315,7 @@ export default async function ServicesPage() {
             </div>
           </section>
           </div>
-        </div>
+        </main>
         <Footer />
       </>
     )

--- a/CDA-WEBSITE/cda-frontend/src/app/team/page.js
+++ b/CDA-WEBSITE/cda-frontend/src/app/team/page.js
@@ -1,5 +1,6 @@
 import Header from '../../components/Header'
 import Footer from '../../components/Footer'
+import HeroSection from '@/components/GlobalBlocks/HeroSection'
 import Link from 'next/link'
 import Image from 'next/image'
 import { sanitizeTitleHtml } from '@/lib/sanitizeTitleHtml'
@@ -146,32 +147,39 @@ export default async function TeamPage() {
     <>
       <Header />
 
-      {/* 1) Hero Individual (reuse homepage hero classes) */}
+      {/* 1) Hero Individual */}
       {header && (
-        <section className="home-hero-section bg-white">
-          <div className="home-header-grid mx-auto w-full max-w-[1620px] px-4 md:px-6 lg:px-8">
-            <div className="home-header-text text-center md:text-left">
-              <h1 className="cda-page-title title-large-light-blue" dangerouslySetInnerHTML={{ __html: sanitizeTitleHtml(header.title || 'Team') }} />
-              {header.description && (
-                <div className="home-hero-subtitle" dangerouslySetInnerHTML={{ __html: header.description }} />
-              )}
-              {header.cta?.url && (
-                <div className="home-header-cta home-hero-cta">
-                  <a href={header.cta.url} className="button-l" target={header.cta.target || '_self'}>
-                    {header.cta.title || 'Contact Us'}
-                  </a>
-                </div>
-              )}
-            </div>
-            <div className="home-header-illustration-wrap">
-              {header.image?.node?.sourceUrl ? (
-                <img src={header.image.node.sourceUrl} alt={header.image.node.altText || 'Team illustration'} width={700} height={520} className="home-header-illustration" />
-              ) : (
-                <div className="home-hero-illustration-placeholder"><p>Upload illustration in WP → Team → Header Section</p></div>
-              )}
-            </div>
-          </div>
-        </section>
+        <HeroSection
+          sectionClassName="bg-white"
+          titleHtml={sanitizeTitleHtml(header.title || 'Team')}
+          titleClassName="cda-page-title title-large-light-blue"
+          descriptionHtml={header.description || ''}
+          ctas={[
+            header.cta?.url
+              ? {
+                  href: header.cta.url,
+                  label: header.cta.title || 'Contact Us',
+                  target: header.cta.target || '_self',
+                  className: 'button-l',
+                }
+              : null,
+          ]}
+          image={
+            header.image?.node?.sourceUrl ? (
+              <img
+                src={header.image.node.sourceUrl}
+                alt={header.image.node.altText || 'Team illustration'}
+                width={700}
+                height={520}
+                className="cda-hero__image-media"
+              />
+            ) : (
+              <div className="cda-hero__image-placeholder">
+                <p>Upload illustration in WP → Team → Header Section</p>
+              </div>
+            )
+          }
+        />
       )}
 
       {/* 2) Meet the founder */}

--- a/CDA-WEBSITE/cda-frontend/src/components/GlobalBlocks/HeroSection.jsx
+++ b/CDA-WEBSITE/cda-frontend/src/components/GlobalBlocks/HeroSection.jsx
@@ -1,0 +1,161 @@
+import { isValidElement } from 'react'
+
+const defaultContainerClassName = 'mx-auto w-full max-w-[1620px] px-4 md:px-6 lg:px-8'
+
+const normalizeCtas = (ctas) => {
+  if (!Array.isArray(ctas)) return []
+  return ctas
+    .map((cta, index) => {
+      if (!cta) return null
+      if (isValidElement(cta)) {
+        return { key: `cta-node-${index}`, node: cta }
+      }
+      if (typeof cta === 'object') {
+        const {
+          href = '#',
+          url,
+          label,
+          title,
+          text,
+          target,
+          rel,
+          className = 'button-l',
+        } = cta
+        const content = label || title || text
+        if (!content) return null
+        const finalTarget = target || '_self'
+        const finalRel = rel || (finalTarget === '_blank' ? 'noopener noreferrer' : undefined)
+        return {
+          key: `cta-link-${index}`,
+          node: (
+            <a
+              href={url || href}
+              target={finalTarget}
+              rel={finalRel}
+              className={className}
+            >
+              {content}
+            </a>
+          ),
+        }
+      }
+      if (typeof cta === 'string') {
+        return {
+          key: `cta-string-${index}`,
+          node: <span>{cta}</span>,
+        }
+      }
+      return null
+    })
+    .filter(Boolean)
+}
+
+export default function HeroSection({
+  sectionClassName = 'bg-white',
+  containerClassName = defaultContainerClassName,
+  eyebrow,
+  eyebrowClassName = '',
+  title,
+  titleHtml,
+  titleClassName = '',
+  titleStyle,
+  description,
+  descriptionHtml,
+  descriptionClassName = '',
+  ctas = [],
+  ctaWrapperClassName = '',
+  image = null,
+  imageWrapperClassName = '',
+  id,
+}) {
+  const normalizedTitle = (() => {
+    if (titleHtml) {
+      return (
+        <h1
+          className={`cda-hero__title-text ${titleClassName}`.trim()}
+          style={titleStyle}
+          dangerouslySetInnerHTML={{ __html: titleHtml }}
+        />
+      )
+    }
+    if (isValidElement(title)) {
+      return title
+    }
+    if (title) {
+      return (
+        <h1 className={`cda-hero__title-text ${titleClassName}`.trim()} style={titleStyle}>
+          {title}
+        </h1>
+      )
+    }
+    return null
+  })()
+
+  const normalizedDescription = (() => {
+    if (descriptionHtml) {
+      return (
+        <div
+          className={`cda-hero__text-content ${descriptionClassName}`.trim()}
+          dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+        />
+      )
+    }
+    if (isValidElement(description)) {
+      return (
+        <div className={`cda-hero__text-content ${descriptionClassName}`.trim()}>
+          {description}
+        </div>
+      )
+    }
+    if (description) {
+      return (
+        <p className={`cda-hero__text-content ${descriptionClassName}`.trim()}>
+          {description}
+        </p>
+      )
+    }
+    return null
+  })()
+
+  const ctaItems = normalizeCtas(ctas)
+  const imageNode = isValidElement(image) ? image : null
+
+  return (
+    <section className={`cda-hero ${sectionClassName}`.trim()} id={id}>
+      <div className={`cda-hero__container ${containerClassName}`.trim()}>
+        <div className="cda-hero__grid">
+          {(eyebrow || normalizedTitle) && (
+            <div className="cda-hero__title">
+              {eyebrow && (
+                <p className={`cda-hero__eyebrow ${eyebrowClassName}`.trim()}>{eyebrow}</p>
+              )}
+              {normalizedTitle}
+            </div>
+          )}
+
+          {imageNode && (
+            <div className={`cda-hero__image ${imageWrapperClassName}`.trim()}>
+              {imageNode}
+            </div>
+          )}
+
+          {normalizedDescription && (
+            <div className="cda-hero__text">
+              {normalizedDescription}
+            </div>
+          )}
+
+          {ctaItems.length > 0 && (
+            <div className={`cda-hero__cta ${ctaWrapperClassName}`.trim()}>
+              {ctaItems.map((item) => (
+                <span key={item.key} className="cda-hero__cta-item">
+                  {item.node}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/CDA-WEBSITE/cda-frontend/src/styles/global.css
+++ b/CDA-WEBSITE/cda-frontend/src/styles/global.css
@@ -2628,34 +2628,194 @@
   color: #fff;
 }
 
-/* Service Hero Section Styles */
-.service-hero {
-  background-color: #ffffff;
-  padding: 5rem 1rem;
-}
-
+/* Service hero typography helpers */
 .service-hero-title {
-  color: #000000 !important;
-}
-
-.service-hero-content {
-  max-width: 1620px;
-  margin: 0 auto;
+  color: #000000;
 }
 
 .service-hero-subtitle {
-  font-family: 'Poppins', sans-serif;
+  font-family: var(--font-poppins), var(--font-inter), sans-serif;
   font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-bottom: 12px;
 }
 
 .service-hero-description {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-inter), ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
 }
 
-.service-hero-image {
+/* Shared hero layout */
+.cda-hero {
+  background-color: #ffffff;
+  padding: 24px 0 40px;
+}
+
+@media (min-width: 768px) {
+  .cda-hero {
+    padding: 88px 0;
+  }
+}
+
+.cda-hero__container {
+  width: 100%;
+  max-width: 1620px;
+  margin: 0 auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+@media (min-width: 768px) {
+  .cda-hero__container {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .cda-hero__container {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}
+
+.cda-hero__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "title"
+    "image"
+    "text"
+    "cta";
+  row-gap: 24px;
+  column-gap: 0;
+  justify-items: center;
+}
+
+.cda-hero__title,
+.cda-hero__text,
+.cda-hero__cta {
+  width: 100%;
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.cda-hero__title {
+  grid-area: title;
+  text-align: center;
+}
+
+.cda-hero__title-text {
+  margin: 0;
+}
+
+.cda-hero__eyebrow {
+  font-family: var(--font-poppins), var(--font-inter), sans-serif;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-bottom: 0.75rem;
+}
+
+.cda-hero__image {
+  grid-area: image;
   display: flex;
   justify-content: center;
+}
+
+.cda-hero__image-media {
+  width: min(560px, 100%);
+  height: auto;
+}
+
+@media (max-width: 767px) {
+  .cda-hero__image-media {
+    width: min(320px, 90%);
+  }
+}
+
+.cda-hero__image-placeholder {
+  width: min(520px, 100%);
+  min-height: 260px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
+  text-align: center;
+  gap: 12px;
+  border: 1px dashed #d1d5db;
+  background-color: #f9fafb;
+  color: #4b5563;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.cda-hero__text {
+  grid-area: text;
+  text-align: center;
+}
+
+.cda-hero__text-content {
+  margin: 0;
+  font-family: var(--font-inter), ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+  font-size: 0.9375rem;
+  line-height: 1.75;
+  color: #4b5563;
+}
+
+@media (min-width: 768px) {
+  .cda-hero__text-content {
+    font-size: 1.0625rem;
+  }
+}
+
+.cda-hero__cta {
+  grid-area: cta;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 16px 24px;
+}
+
+.cda-hero__cta-item {
+  display: inline-flex;
+}
+
+@media (min-width: 1024px) {
+  .cda-hero__grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-areas:
+      "title image"
+      "text image"
+      "cta image";
+    column-gap: 4rem;
+    row-gap: 24px;
+    justify-items: stretch;
+    align-items: center;
+  }
+
+  .cda-hero__title,
+  .cda-hero__text,
+  .cda-hero__cta {
+    text-align: left;
+    margin-left: 0;
+    margin-right: 0;
+    justify-self: flex-start;
+  }
+
+  .cda-hero__image {
+    justify-content: flex-end;
+  }
+
+  .cda-hero__cta {
+    justify-content: flex-start;
+  }
 }
 
 /* Global override: Remove all border-radius from the website */


### PR DESCRIPTION
## Summary
- add a reusable HeroSection component to provide consistent hero markup and CTA rendering
- refactor the home, about, team, services listing, and service detail pages to use the shared hero component
- introduce unified hero styling in global.css to ensure the requested mobile ordering and spacing

## Testing
- npm run lint *(fails: numerous pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d404c2c7248329a67d6d6e8d72952f